### PR TITLE
Implement caching for geolocation lookups

### DIFF
--- a/app/use_cases/find_geolocation_use_case.rb
+++ b/app/use_cases/find_geolocation_use_case.rb
@@ -10,15 +10,27 @@ class FindGeolocationUseCase
     @gateway = gateway
   end
 
-  def call
-    return nil if address.blank? || geolocation.blank?
+  CACHE_EXPIRATION = 24.hours
 
-    { latitude:, longitude: }
+  def call
+    Rails.cache.fetch(cache_key, expires_in: CACHE_EXPIRATION) do
+      fetch_geolocation
+    end
   end
 
   private
 
   attr_reader :zipcode, :gateway
+
+  def cache_key
+    "geolocation/#{zipcode}"
+  end
+
+  def fetch_geolocation
+    return nil if address.blank? || geolocation.blank?
+
+    { latitude:, longitude: }
+  end
 
   def address
     @address ||= gateway.by_zipcode(zipcode:)

--- a/spec/use_cases/find_geolocation_use_case_spec.rb
+++ b/spec/use_cases/find_geolocation_use_case_spec.rb
@@ -26,8 +26,26 @@ RSpec.describe FindGeolocationUseCase do
       allow(gateway).to receive(:by_zipcode).with(zipcode:).and_return(geolocation_data)
     end
 
+    around do |example|
+      original_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+      Rails.cache = original_cache
+    end
+
     it 'fetches geolocation data for the given zipcode' do
       expect(call).to eq(expected_result)
+    end
+
+    context 'when the geolocation is cached' do
+      before do
+        Rails.cache.write("geolocation/#{zipcode}", expected_result)
+      end
+
+      it 'returns the cached data without calling the gateway' do
+        expect(gateway).not_to receive(:by_zipcode)
+        expect(call).to eq(expected_result)
+      end
     end
 
     context 'when the gateway raises an error' do


### PR DESCRIPTION
## Summary
- add caching in `FindGeolocationUseCase`
- update unit test for the use case to cover caching logic

## Testing
- `RBENV_VERSION=3.3.8 bundle exec rspec` *(fails: command not found)*
- `RBENV_VERSION=3.3.8 bundle install --jobs 4` *(fails: Ruby version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_683f64477df08330a67399838b05e288